### PR TITLE
Add new prop forbiddenRedirectPath

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,5 @@
 {
   "editor.formatOnSave": true,
-  "prettier.eslintIntegration": true,
   "eslint.validate": [
     {
       "language": "javascript",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Added
+
+- New prop `forbiddenRedirectPath`.
+
 ## [0.1.1] - 2019-11-06
 
 ### Fixed

--- a/docs/README.md
+++ b/docs/README.md
@@ -43,7 +43,8 @@ This component will check if the logged in user has all conditions rules specifi
 
 | Prop name                | Default value | Possible values       | Description                                                                |
 | ------------------------ | ------------- | --------------------- | -------------------------------------------------------------------------- |
-| redirectPath             | `/login`      | (anything)            | Path which the user will be redirected if not allowed                      |
+| redirectPath             | `/login`      | (anything)            | Path which the not logged in user will be redirected                       |
+| forbiddenRedirectPath    | `/login`      | (anything)            | Path which the logged in user will be redirected if not allowed            |
 | defaultContentVisibility | `visible`     | `visible` or `hidden` | Should the content be visible or hidden while checking the user condition? |
 
 > _Important:_ Using `hidden` will make all the page content be rendered on the client, that is, the page will not be Server Side Rendered (SSR). That is due to the fact that this check is user-based, making it impossible to cache.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,23 +1,21 @@
+📢 Use this project, [contribute](https://github.com/vtex-apps/challenge-tp-condition) to it or open issues to help evolve it using [Store Discussion](https://github.com/vtex-apps/store-discussion).
+
 # Challenge Trade Policy Condition
 
-> Challenge that checks if an user can access the current Trade Policy based on a specified condition rule.
+This component will check if the logged in user has all conditions rules specified in the Trade Policy configuration. If the user is not logged in they will be redirected to `redirectPath`. If the user is logged in but not authorized, they will be redirected to `forbiddenRedirectPath`. If allowed, it will render the page.
 
-## Usage
+## Configuration
 
-Add this app to your theme dependencies:
+1. Import the app to your theme's dependencies in the `manifest.json`, for example:
 
-```js
-// manifest.json
-// ...
+```json
   "dependencies": {
     // ...
     "vtex.challenge-tp-condition": "0.x"
   }
 ```
 
-Add the block `challenge.trade-policy-condition` to all pages that you want to protect as a `parent` component.
-
-Example:
+2. Add the block `challenge.trade-policy-condition` to all pages that you want to protect as a `parent` component:
 
 ```diff
  "store.home": {
@@ -34,12 +32,6 @@ Example:
 +   }
  },
 ```
-
-This component will check if the logged in user has all conditions rules specified in the Trade Policy configuration. If not the user will be redirected to `/login`. If allowed, it will render the page.
-
-## API
-
-`challenge.trade-policy-condition` has some props that can be set.
 
 | Prop name                | Default value | Possible values       | Description                                                                |
 | ------------------------ | ------------- | --------------------- | -------------------------------------------------------------------------- |

--- a/react/ChallengeTradePolicyCondition.tsx
+++ b/react/ChallengeTradePolicyCondition.tsx
@@ -95,7 +95,14 @@ const ChallengeTradePolicyCondition: FC<Props> = ({
   const sessionResponse = useSessionResponse()
   const isUnauthorized = useSessionUnauthorized(sessionResponse)
   const isForbidden = useSessionForbidden(sessionResponse)
-  const skipProfileCheck = Boolean(!isUnauthorized) || Boolean(!isForbidden)
+
+  const skipProfileCheck =
+    // Still checking for session
+    (isUnauthorized === null && isForbidden === null) ||
+    // We already know that it's not possible
+    isUnauthorized === true ||
+    isForbidden === true
+
   const profileAllowed = useProfileAllowed(skipProfileCheck)
 
   useRedirect(isUnauthorized === true || profileAllowed === false, redirectPath)

--- a/react/__tests__/index.test.tsx
+++ b/react/__tests__/index.test.tsx
@@ -1,4 +1,4 @@
-describe('Orders List Scenarios', () => {
+describe('Challenge Trade Policy Condition', () => {
   it('should work', () => {
     expect(1).toBe(1)
   })

--- a/react/package.json
+++ b/react/package.json
@@ -25,7 +25,7 @@
     "eslint-config-vtex-react": "^5.0.1",
     "prettier": "^1.18.2",
     "prop-types": "^15.7.2",
-    "typescript": "3.5.2"
+    "typescript": "3.7.3"
   },
   "version": "0.1.1"
 }

--- a/react/typings/vtex.render-runtime.d.ts
+++ b/react/typings/vtex.render-runtime.d.ts
@@ -62,11 +62,16 @@ declare module 'vtex.render-runtime' {
     message: string
   }
 
+  interface SessionForbidden {
+    type: 'Forbidden'
+    message: string
+  }
+
   export interface RenderSession {
     sessionPromise: Promise<SessionPromise>
   }
 
   export interface SessionPromise {
-    response: Session | SessionUnauthorized
+    response: Session | SessionUnauthorized | SessionForbidden
   }
 }

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -5206,10 +5206,10 @@ type-fest@^0.5.2:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.5.2.tgz#d6ef42a0356c6cd45f49485c3b6281fc148e48a2"
   integrity sha512-DWkS49EQKVX//Tbupb9TFa19c7+MK1XmzkrZUR8TAktmE/DizXoaoJV6TZ/tSIPXipqNiRI6CyAe7x69Jb6RSw==
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.7.3:
+  version "3.7.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.3.tgz#b36840668a16458a7025b9eabfad11b66ab85c69"
+  integrity sha512-Mcr/Qk7hXqFBXMN7p7Lusj1ktCBydylfQM/FZCk5glCNQJrCUKPkMHdo9R0MTFWsC/4kPFvDS0fDPvukfCkFsw==
 
 typescript@^3.3.3333:
   version "3.5.3"


### PR DESCRIPTION
#### How to test it? \*

Use the linked workspace: https://breno--storecomponents.myvtex.com/?sc=3

This workspace has the following changes in store-theme:

1. Add the following blocks to `home.json`
```diff
       "rich-text#link",
       "newsletter"
-    ]
+    ],
+    "parent": {
+      "challenge": "challenge.trade-policy-condition"
+    }
+  },
+
+  "challenge.trade-policy-condition": {
+    "props": {
+      "forbiddenRedirectPath": "/foo"
+    }
```

2. To its `manifest.json`:

```diff
-    "vtex.order-placed": "1.x"
+    "vtex.order-placed": "1.x",
+    "vtex.challenge-tp-condition": "0.x"
   },
```

#### Describe alternatives you've considered, if any. \*

No alternatives.

#### Related to / Depends on \*

N/a
