### PR TITLE
Update ChallengeTradePolicyCondition.tsx

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+
+- Fallback to `window.location.search` if `window.location.hash` is not present
+
 ## [0.6.0] - 2021-04-29 [DEPRECATED] 
 
 ### Added

--- a/react/ChallengeTradePolicyCondition.tsx
+++ b/react/ChallengeTradePolicyCondition.tsx
@@ -21,7 +21,7 @@ const useRedirect = (condition: boolean, path: string) => {
 
     const url = canUseDOM
       ? window.location.pathname +
-      (window.location.hash == "" ? window.location.search : window.location.hash)
+      (window.location.hash || window.location.search)
       : // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (global as any).__pathname__
 

--- a/react/ChallengeTradePolicyCondition.tsx
+++ b/react/ChallengeTradePolicyCondition.tsx
@@ -20,9 +20,10 @@ const useRedirect = (condition: boolean, path: string) => {
     }
 
     const url = canUseDOM
-      ? window.location.pathname + window.location.hash
+      ? window.location.pathname +
+      (window.location.hash == "" ? window.location.search : window.location.hash)
       : // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        (global as any).__pathname__
+      (global as any).__pathname__
 
     navigate({
       to: `${path}?returnUrl=${encodeURIComponent(url)}`,


### PR DESCRIPTION
Check for window.location.search when window.location.hash is not provided

#### What problem is this solving?

We have a customer reporting that when using an URL with querystring. The app is dropping the querystring when the redirectPath is used. For example, when the querystring qty=1&partnum=5022158 was in the initial URL, the returnURL would drop the querystring, which would cause a redirection to the incomplete URL.

#### How to test it?

<!--- Don't forget to add a link to a Workspace where this branch is linked -->

[Workspace][(https://rjant--briggsandstratton.myvtex.com/eparts/addtocart?qty=1&partnum=5022158)

#### Screenshots or example usage:

<!--- Add some images or gifs to showcase changes in behavior or layout. Example: Before and after images -->
Before:
![image](https://user-images.githubusercontent.com/88678995/167889929-35b3071c-4680-477a-b0a8-2dd9f65ff483.png)

After:
<img width="1814" alt="Screen Shot 2022-05-11 at 11 33 43 AM" src="https://user-images.githubusercontent.com/88678995/167890080-e9d64d67-e322-4e89-87c1-48c75ca31cde.png">


#### Describe alternatives you've considered, if any.

Obs: This is my first PR. I have tried to follow this [document](https://developers.vtex.com/vtex-developer-docs/docs/contributing) during the creation, but please let me know what needs to be changed or improved for future reference.  Thank you!

<!--- Optional -->

#### Related to / Depends on

<!--- Optional -->

#### How does this PR make you feel? [:link:](http://giphy.com/)

<!-- Go to http://giphy.com/ and pick a gif that represents how this PR makes you feel -->

![](put .gif link here - can be found under "advanced" on giphy)
