### PR TITLE
EDU-17940: rename Trade Policy to Sales Channel in documentation

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 📢 Use this project, [contribute](https://github.com/vtex-apps/challenge-tp-condition) to it or open issues to help evolve it using [Store Discussion](https://github.com/vtex-apps/store-discussion).
 
-# Challenge Trade Policy Condition
+# Challenge sales channel condition
 
 <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-0-orange.svg?style=flat-square)](#contributors-)
@@ -8,7 +8,9 @@
 
 Used in B2B environments, the Challenge block is a non-rendered block responsible for checking if a user is allowed to access the store's content. 
 
-:information_source: This check is made according to the Condition Rule specified in the Trade Policy configuration, one of the steps needed to [**configure a B2B environment in VTEX IO**](https://vtex.io/docs/recipes/store/configuring-a-b2b-environment). 
+ℹ️ This check is made according to the Condition Rule specified in the Sales Channel configuration, one of the steps needed to [**configure a B2B environment in VTEX IO**](https://vtex.io/docs/recipes/store/configuring-a-b2b-environment). 
+
+> ⚠️ The feature formerly known as **Trade Policy** has been renamed to **Sales Channel**. Code references (e.g., `challenge.trade-policy-condition`) still use the old naming for backward compatibility.
 
 ## Configuration
 
@@ -56,7 +58,7 @@ Used in B2B environments, the Challenge block is a non-rendered block responsibl
 | `forbiddenRedirectPath`    | `string`    | Path to which the logged in user will be redirected if not allowed access according to the Condition Rule         |   `/login`      |
 | `defaultContentVisibility` |   `enum`  |  Whether the store's content should be visible (`visible`) or hidden (`hidden`) while the Challenge block is verifying the user's access permission | `visible` | 
  
-:warning: Using `hidden` as the `defaultContentVisibility` value result in the entire page's content being rendered on the client side (in a scenario in which the check concludes that the user has permission to access the store). The page will not be Server Side Rendered (SSR) due to the fact that this verification process is user-based, making it impossible to cache.
+> ⚠️ Using `hidden` as the `defaultContentVisibility` value result in the entire page's content being rendered on the client side (in a scenario in which the check concludes that the user has permission to access the store). The page will not be Server Side Rendered (SSR) due to the fact that this verification process is user-based, making it impossible to cache.
 
 ## Customization
 


### PR DESCRIPTION
- Renamed "Trade Policy" references to "Sales Channel" in the documentation text to align with the platform-wide terminology update.
- Replaced GitHub-specific emoji shortcodes (`:information_source:`, `:warning:`) with actual Unicode emojis for consistent rendering across all platforms.
- Added a warning note clarifying that code references (e.g., `challenge.trade-policy-condition`) still use the old naming for backward compatibility.

## Why

The platform is transitioning from the "Trade Policy" terminology to "Sales Channel". This update ensures the documentation reflects the correct naming while preserving backward-compatible code identifiers.
