### PR TITLE
chore: STR-969 catalog platform-flow-id (Shopper#1, Merch#1)

### DIFF
--- a/.vtex/catalog-info.yaml
+++ b/.vtex/catalog-info.yaml
@@ -13,7 +13,7 @@ metadata:
     vtex.com/o11y-os-index: ""
     grafana/dashboard-selector: ""
     github.com/project-slug: vtex-apps/challenge-tp-condition
-    vtex.com/platform-flow-id: ""
+    vtex.com/platform-flow-id: Shopper#1,Merch#1
     backstage.io/techdocs-ref: dir:../
     vtex.com/application-id: GQ499BJP
 spec:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Changed
+
+- Update DK Catalog platform-flow-id
+
 ## [0.6.2] - 2026-03-30
 
 ### Changed


### PR DESCRIPTION
## Jira

https://vtex-dev.atlassian.net/browse/STR-969

## Summary

Updates Backstage catalog metadata by setting `vtex.com/platform-flow-id` in `.vtex/catalog-info.yaml` to match the **Platform Flows (Dark Kitchen)** classification for this component (initiative STR-969).

## Change

| Annotation | Value |
|------------|-------|
| `vtex.com/platform-flow-id` | `Shopper#1,Merch#1` |

**Convention:** multiple DK IDs are **comma-separated with no spaces**.

## Classification context (source artifact)

The following summary is taken from the internal classification table (Portuguese) used for STR-969:

> **Bloco:** validação B2B de acesso por regra de canal (não renderizado). **Decisão:** README: condição de sales channel antes de exibir loja → shopper vê ou não conteúdo (**Shopper#1**); regra ligada a configuração de oferta/canal (**Merch#1**).

## Changelog

- `CHANGELOG.md` — **[Unreleased]** → **Changed**: Update DK Catalog platform-flow-id


---

Reviewers: @vmourac-vtex @iago1501
